### PR TITLE
Fix crash of stereo_detector when no plane was found.

### DIFF
--- a/stereo_detector/src/lib/keypoint_detection.cpp
+++ b/stereo_detector/src/lib/keypoint_detection.cpp
@@ -144,7 +144,7 @@ void getPlane(
 	seg.segment(*inliers, coefficients); // Gets the plane coefficients (a*x + b*y + c*z = d)
 
 	// Check if a plane is found
-	if (inliers->indices.size() == 1) {
+	if (inliers->indices.size() <= 1) {
 		throw std::runtime_error("Could not estimate a planar model for the given point cloud.");
 	}
 

--- a/stereo_detector/src/lib/node_lib.cpp
+++ b/stereo_detector/src/lib/node_lib.cpp
@@ -145,7 +145,7 @@ void StereoDetectorNode::callback(
 		point_cloud_publisher_.publish(out);
 		sphere_marker_publisher_.publish(toMarkers(processed, image->header));
 	} catch (std::exception & e) {
-		ROS_INFO_ONCE("Ignoring exceptions in at least one frame.");
+		ROS_INFO_ONCE("Ignoring exceptions in at least one frame. Reason: %s", e.what());
 	}
 }
 


### PR DESCRIPTION
When running the stereo_detector, the program crashed as seemingly there were no planes to find. The exception was thrown only when exactly one inlier point was found, changing it to less than 1 fixed the problem for me (at least now the program doesn't crash completely, still waiting for the board to really test everything).

I didn't really think it through but shouldn't the check be for values less than 3, as 3 points are necessary to define a plane?